### PR TITLE
Support shaders, programs, and techniques

### DIFF
--- a/tiny_gltf_loader.h
+++ b/tiny_gltf_loader.h
@@ -613,7 +613,7 @@ static bool LoadExternalFile(std::vector<unsigned char> *out, std::string *err,
   std::string filepath = FindFile(paths, filename);
   if (filepath.empty()) {
     if (err) {
-      (*err) += "File not found : " + filename;
+      (*err) += "File not found : " + filename + "\n";
     }
     return false;
   }
@@ -621,7 +621,7 @@ static bool LoadExternalFile(std::vector<unsigned char> *out, std::string *err,
   std::ifstream f(filepath.c_str(), std::ifstream::binary);
   if (!f) {
     if (err) {
-      (*err) += "File open error : " + filepath;
+      (*err) += "File open error : " + filepath + "\n";
     }
     return false;
   }

--- a/tiny_gltf_loader.h
+++ b/tiny_gltf_loader.h
@@ -716,6 +716,11 @@ static bool IsDataURI(const std::string &in) {
     return true;
   }
 
+  header = "data:text/plain;base64,";
+  if (in.find(header) == 0) {
+    return true;
+  }
+
   return false;
 }
 
@@ -739,6 +744,13 @@ static bool DecodeDataURI(std::vector<unsigned char> *out,
     header = "data:image/png;base64,";
     if (in.find(header) == 0) {
       data = base64_decode(in.substr(header.size()));  // cut mime string.
+    }
+  }
+
+  if (data.empty()) {
+    header = "data:text/plain;base64,";
+    if (in.find(header) == 0) {
+      data = base64_decode(in.substr(header.size()));
     }
   }
 

--- a/tiny_gltf_loader.h
+++ b/tiny_gltf_loader.h
@@ -66,6 +66,36 @@ namespace tinygltf {
 #define TINYGLTF_COMPONENT_TYPE_FLOAT (5126)
 #define TINYGLTF_COMPONENT_TYPE_DOUBLE (5127)
 
+// Redeclarations of the above for technique.parameters.
+#define TINYGLTF_PARAMETER_TYPE_BYTE (5120)
+#define TINYGLTF_PARAMETER_TYPE_UNSIGNED_BYTE (5121)
+#define TINYGLTF_PARAMETER_TYPE_SHORT (5122)
+#define TINYGLTF_PARAMETER_TYPE_UNSIGNED_SHORT (5123)
+#define TINYGLTF_PARAMETER_TYPE_INT (5124)
+#define TINYGLTF_PARAMETER_TYPE_UNSIGNED_INT (5125)
+#define TINYGLTF_PARAMETER_TYPE_FLOAT (5126)
+
+#define TINYGLTF_PARAMETER_TYPE_FLOAT_VEC2 (35664)
+#define TINYGLTF_PARAMETER_TYPE_FLOAT_VEC3 (35665)
+#define TINYGLTF_PARAMETER_TYPE_FLOAT_VEC4 (35666)
+
+#define TINYGLTF_PARAMETER_TYPE_INT_VEC2 (35667)
+#define TINYGLTF_PARAMETER_TYPE_INT_VEC3 (35668)
+#define TINYGLTF_PARAMETER_TYPE_INT_VEC4 (35669)
+
+#define TINYGLTF_PARAMETER_TYPE_BOOL (35670)
+#define TINYGLTF_PARAMETER_TYPE_BOOL_VEC2 (35671)
+#define TINYGLTF_PARAMETER_TYPE_BOOL_VEC3 (35672)
+#define TINYGLTF_PARAMETER_TYPE_BOOL_VEC4 (35673)
+
+#define TINYGLTF_PARAMETER_TYPE_FLOAT_MAT2 (35674)
+#define TINYGLTF_PARAMETER_TYPE_FLOAT_MAT3 (35675)
+#define TINYGLTF_PARAMETER_TYPE_FLOAT_MAT4 (35676)
+
+#define TINYGLTF_PARAMETER_TYPE_SAMPLER_2D (35678)
+
+// End parameter types
+
 #define TINYGLTF_TYPE_VEC2 (2)
 #define TINYGLTF_TYPE_VEC3 (3)
 #define TINYGLTF_TYPE_VEC4 (4)
@@ -87,6 +117,9 @@ namespace tinygltf {
 
 #define TINYGLTF_TARGET_ARRAY_BUFFER (34962)
 #define TINYGLTF_TARGET_ELEMENT_ARRAY_BUFFER (34963)
+
+#define TINYGLTF_SHADER_TYPE_VERTEX_SHADER (35633)
+#define TINYGLTF_SHADER_TYPE_FRAGMENT_SHADER (35632)
 
 typedef struct {
   std::string string_value;
@@ -200,6 +233,36 @@ typedef struct {
 } Buffer;
 
 typedef struct {
+  std::string name;
+  int type;
+  std::vector<unsigned char> source;
+} Shader;
+
+typedef struct {
+  std::string name;
+  std::string vertexShader;
+  std::string fragmentShader;
+  std::vector<std::string> attributes;
+} Program;
+
+typedef struct
+{
+  int count;
+  std::string node;
+  std::string semantic;
+  int type;
+  Parameter value;
+} TechniqueParameter;
+
+typedef struct {
+  std::string name;
+  std::string program;
+  std::map<std::string, TechniqueParameter> parameters;
+  std::map<std::string, std::string> attributes;
+  std::map<std::string, std::string> uniforms;
+} Technique;
+
+typedef struct {
   std::string generator;
   std::string version;
   std::string profile_api;
@@ -221,6 +284,9 @@ class Scene {
   std::map<std::string, Node> nodes;
   std::map<std::string, Texture> textures;
   std::map<std::string, Image> images;
+  std::map<std::string, Shader> shaders;
+  std::map<std::string, Program> programs;
+  std::map<std::string, Technique> techniques;
   std::map<std::string, std::vector<std::string> > scenes;  // list of nodes
 
   std::string defaultScene;
@@ -1412,6 +1478,36 @@ static bool ParseNode(Node *node, std::string *err, const picojson::object &o) {
   return true;
 }
 
+static bool ParseParameterProperty(Parameter *param, std::string *err,
+                                   const picojson::object &o,
+                                   const std::string &prop, bool required)
+{
+  double num_val;
+
+  // A parameter value can either be a string or an array of either a boolean or
+  // a number. Booleans of any kind aren't supported here. Granted, it
+  // complicates the Parameter structure and breaks it semantically in the sense
+  // that the client probably works off the assumption that if the string is
+  // empty the vector is used, etc. Would a tagged union work?
+  if (ParseStringProperty(&param->string_value, err, o, prop, false)) {
+    // Found string property.
+    return true;
+  } else if (ParseNumberArrayProperty(&param->number_array, err,o,prop,false)) {
+    // Found a number array.
+    return true;
+  } else if (ParseNumberProperty(&num_val, err, o, prop, false)) {
+    param->number_array.push_back(num_val);
+    return true;
+  } else {
+    if(required) {
+      if(err) {
+        (*err) += "parameter must be a string or number / number array.\n";
+      }
+    }
+    return false;
+  }
+}
+
 static bool ParseMaterial(Material *material, std::string *err,
                           const picojson::object &o) {
   ParseStringProperty(&material->name, err, o, "name", false);
@@ -1419,28 +1515,145 @@ static bool ParseMaterial(Material *material, std::string *err,
 
   material->values.clear();
   picojson::object::const_iterator valuesIt = o.find("values");
+
   if ((valuesIt != o.end()) && (valuesIt->second).is<picojson::object>()) {
+
     const picojson::object &values_object =
         (valuesIt->second).get<picojson::object>();
+
     picojson::object::const_iterator it(values_object.begin());
     picojson::object::const_iterator itEnd(values_object.end());
 
     for (; it != itEnd; it++) {
-      // Assume number values.
       Parameter param;
-      if (ParseStringProperty(&param.string_value, err, values_object,
-                              it->first, false)) {
-        // Found string property.
-      } else if (!ParseNumberArrayProperty(&param.number_array, err,
-                                           values_object, it->first, false)) {
-        // Fallback to numer property.
-        double value;
-        if (ParseNumberProperty(&value, err, values_object, it->first, false)) {
-          param.number_array.push_back(value);
-        }
+      if(ParseParameterProperty(&param, err, values_object, it->first, false)) {
+        material->values[it->first] = param;
       }
+    }
+  }
 
-      material->values[it->first] = param;
+  return true;
+}
+
+static bool ParseShader(Shader *shader, std::string *err,
+                        const picojson::object &o, const std::string &basedir) {
+  std::string uri;
+  if (!ParseStringProperty(&uri, err, o, "uri", true)) {
+    return false;
+  }
+
+  // Load shader source from data uri
+  // TODO: Support ascii or utf-8 data uris.
+  if (IsDataURI(uri)) {
+    if (!DecodeDataURI(&shader->source, uri, 0, false)) {
+      if (err) {
+        (*err) += "Failed to decode 'uri'.\n";
+      }
+      return false;
+    }
+  } else {
+    // Assume external file
+    if (!LoadExternalFile(&shader->source, err, uri, basedir, 0, false)) {
+      if (err) {
+        (*err) += "Failed to load external 'uri'.\n";
+      }
+      return false;
+    }
+    if (shader->source.empty()) {
+      if (err) {
+        (*err) += "File is empty.\n";
+      }
+      return false;
+    }
+  }
+
+  double type;
+  if (!ParseNumberProperty(&type, err, o, "type", true)) {
+    return false;
+  }
+
+  shader->type = static_cast<int>(type);
+
+  return true;
+}
+
+static bool ParseProgram(Program *program, std::string *err,
+                        const picojson::object &o) {
+  ParseStringProperty(&program->name, err, o, "name", false);
+
+  if(!ParseStringProperty(&program->vertexShader, err,o, "vertexShader",true)) {
+    return false;
+  }
+  if(!ParseStringProperty(&program->fragmentShader, err, o,
+                          "fragmentShader", true)) {
+    return false;
+  }
+
+  // I suppose the list of attributes isn't needed, but a technique doesn't
+  // really make sense without it.
+  ParseStringArrayProperty(&program->attributes, err, o, "attributes", false);
+
+  return true;
+}
+
+static bool ParseTechniqueParameter(TechniqueParameter *param, std::string *err,
+                                    const picojson::object &o) {
+
+  double count = 1;
+  ParseNumberProperty(&count, err, o, "count", false);
+
+  double type;
+  if(!ParseNumberProperty(&type, err, o, "type", true)) {
+    return false;
+  }
+
+  ParseStringProperty(&param->node, err, o, "node", false);
+  ParseStringProperty(&param->semantic, err, o, "semantic", false);
+
+  ParseParameterProperty(&param->value, err, o, "value", false);
+
+  param->count = static_cast<int>(count);
+  param->type = static_cast<int>(type);
+
+  return true;
+}
+
+static bool ParseTechnique(Technique *technique, std::string *err,
+                           const picojson::object &o) {
+  ParseStringProperty(&technique->name, err, o, "name", false);
+
+  if(!ParseStringProperty(&technique->program, err, o, "program", true)) {
+    return false;
+  }
+
+  ParseStringMapProperty(&technique->attributes, err, o, "attributes", false);
+  ParseStringMapProperty(&technique->uniforms, err, o, "uniforms", false);
+
+  technique->parameters.clear();
+  picojson::object::const_iterator paramsIt = o.find("parameters");
+
+  // Verify parameters is an object
+  if ((paramsIt != o.end()) && (paramsIt->second).is<picojson::object>()) {
+
+    // For each parameter in params_object.
+    const picojson::object &params_object =
+        (paramsIt->second).get<picojson::object>();
+
+    picojson::object::const_iterator it(params_object.begin());
+    picojson::object::const_iterator itEnd(params_object.end());
+
+    for (; it != itEnd; it++) {
+      TechniqueParameter param;
+
+      // Skip non-objects
+      if(!it->second.is<picojson::object>()) continue;
+
+      // Parse the technique parameter
+      const picojson::object& param_obj = it->second.get<picojson::object>();
+      if(ParseTechniqueParameter(&param, err, param_obj)) {
+        // Add if successful
+        technique->parameters[it->first] = param;
+      }
     }
   }
 
@@ -1715,6 +1928,59 @@ bool TinyGLTFLoader::LoadFromString(Scene *scene, std::string *err,
       }
 
       scene->textures[it->first] = texture;
+    }
+  }
+
+  // 10. Parse Shader
+  if (v.contains("shaders") && v.get("shaders").is<picojson::object>()) {
+    const picojson::object &root = v.get("shaders").get<picojson::object>();
+
+    picojson::object::const_iterator it(root.begin());
+    picojson::object::const_iterator itEnd(root.end());
+    for(; it != itEnd; ++it)
+    {
+      Shader shader;
+      if(!ParseShader(&shader, err, (it->second).get<picojson::object>(),
+                      base_dir)) {
+        return false;
+      }
+
+      scene->shaders[it->first] = shader;
+    }
+  }
+
+  // 11. Parse Program
+  if (v.contains("programs") && v.get("programs").is<picojson::object>()) {
+    const picojson::object &root = v.get("programs").get<picojson::object>();
+
+    picojson::object::const_iterator it(root.begin());
+    picojson::object::const_iterator itEnd(root.end());
+    for(; it != itEnd; ++it)
+    {
+      Program program;
+      if(!ParseProgram(&program, err, (it->second).get<picojson::object>())) {
+        return false;
+      }
+
+      scene->programs[it->first] = program;
+    }
+  }
+
+  // 12. Parse Technique
+  if (v.contains("techniques") && v.get("techniques").is<picojson::object>()) {
+    const picojson::object &root = v.get("techniques").get<picojson::object>();
+
+    picojson::object::const_iterator it(root.begin());
+    picojson::object::const_iterator itEnd(root.end());
+    for(; it != itEnd; ++it)
+    {
+      Technique technique;
+      if(!ParseTechnique(&technique, err,
+                         (it->second).get<picojson::object>())) {
+        return false;
+      }
+
+      scene->techniques[it->first] = technique;
     }
   }
 


### PR DESCRIPTION
Notable changes:
- Load shaders, programs, and techniques (of course).
- Some values from `TINYGLTF_COMPONENT_TYPE_*` have be redefined as `TINYGLTF_PARAMETER_TYPE_*` (for use in a technique's parameters). I felt it could be confusing if client code had to mix the two names.
- Parsing string dictionaries (`std::map<std::string, std::string>`) is now done by the function `ParseStringMapProperty`. I made it for the new code but it turns out it could be used in `ParseMaterial`.
- Parsing parameter values (`materials.values` and `technique.parameter.value`) is now done by the function `ParseParameterProperty` which was also made for the new code but turned out to be useful in `ParsePrimitive`.

Everything seems to work fine. I just loaded in a mildly complex scene and printed the important information. Specifically, I printed shaders, programs, techniques, materials, and meshes / primitives. I made sure to check the latter two because the `ParsePrimitive` and `ParseMaterial` functions were both modified.

The shader loading code should support base64-encoded data, but I didn't get a chance to test this. That being said, it should work fine since it uses pretty much the same code as the image and buffer loading code. I didn't worry about ASCII-encoded data in the URI because I don't personally have a need for it.

I'm not really familiar with the binary extension so I wasn't sure how to load shader data in that case, but everything should (I think) work fine as long as the shader is externally referenced or encoded inline. Anyways, I'd be happy to add that support at some point if you want.

Thanks for making such an awesome library by the way, it's very helpful! ;)
