### PR TITLE
Fix .glb loading (Windows)

### DIFF
--- a/tiny_gltf_loader.h
+++ b/tiny_gltf_loader.h
@@ -2401,7 +2401,7 @@ bool TinyGLTFLoader::LoadBinaryFromFile(Scene *scene, std::string *err,
                                         unsigned int check_sections) {
   std::stringstream ss;
 
-  std::ifstream f(filename.c_str());
+  std::ifstream f(filename.c_str(), std::ios::binary);
   if (!f) {
     ss << "Failed to open file: " << filename << std::endl;
     if (err) {


### PR DESCRIPTION
Fixes loading of https://github.com/KhronosGroup/glTF/blob/master/sampleModels/Duck/glTF-Binary/Duck.glb
