### PR TITLE
Possible fix for child values not being properly deserialized

### DIFF
--- a/tiny_gltf_loader.h
+++ b/tiny_gltf_loader.h
@@ -1021,6 +1021,7 @@ static void ParseObjectProperty(Value *ret, const picojson::object &o) {
     } else if (v.is<picojson::object>()) {
       tinygltf::Value child_value;
       ParseObjectProperty(&child_value, v.get<picojson::object>());
+      vo[it->first] = child_value;
     }
     // TODO(syoyo) binary, array
   }


### PR DESCRIPTION
* Add the child_value parsed by ParseObjectProperty to the return value

The omission of adding child_value to the return object appears to have been an oversight, as it is the only case where the parsed value is not added, and because child_value is otherwise unreferenced.

This change also does give us the value that we are expecting in our use case after loading our glTF.

Was this an oversight or an intentional omission?